### PR TITLE
django-staticfiles is not needed if using Django 1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setup(
     install_requires=[
         'django-mptt>=0.4.2',
         'django-piston==0.2.3rc1',
-        'django-staticfiles>=1.0.1',
         'beautifulsoup>=3.2.0',
         'django-compressor>=0.7.1',
     ],


### PR DESCRIPTION
It should not be explicitly installed in the setup.py.
