### PR TITLE
Prepared django-fiber to easily register models to fiber_admin

### DIFF
--- a/fiber/admin.py
+++ b/fiber/admin.py
@@ -8,12 +8,7 @@ from fiber.editor import get_editor_field_name
 from app_settings import TEMPLATE_CHOICES
 from models import Page, ContentItem, PageContentItem, Image, File
 import admin_forms as forms
-
-
-class FiberAdminSite(admin.AdminSite):
-    pass
-
-fiber_admin_site = FiberAdminSite(name='fiber_admin')
+import fiber_admin
 
 
 class ContentItemAdmin(admin.ModelAdmin):
@@ -123,5 +118,5 @@ admin.site.register(Image)
 admin.site.register(File)
 admin.site.register(Page, PageAdmin)
 
-fiber_admin_site.register(ContentItem, FiberAdminContentItemAdmin)
-fiber_admin_site.register(Page, FiberAdminPageAdmin)
+fiber_admin.site.register(ContentItem, FiberAdminContentItemAdmin)
+fiber_admin.site.register(Page, FiberAdminPageAdmin)

--- a/fiber/admin_urls.py
+++ b/fiber/admin_urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls.defaults import *
 
-from admin import fiber_admin_site
+import fiber_admin
 import admin_views
 
 
@@ -8,5 +8,5 @@ urlpatterns = patterns('',
     url(r'^page/(?P<id>\d+)/move_up/$', admin_views.page_move_up, name='fiber_page_move_up'),
     url(r'^page/(?P<id>\d+)/move_down/$', admin_views.page_move_down, name='fiber_page_move_down'),
     url(r'^login/$', admin_views.fiber_login, name='fiber_login'),
-    (r'^fiber_admin/', include(fiber_admin_site.urls)),
+    (r'^fiber_admin/', include(fiber_admin.site.urls)),
 )

--- a/fiber/fiber_admin/__init__.py
+++ b/fiber/fiber_admin/__init__.py
@@ -1,0 +1,13 @@
+from django.contrib import admin
+from options import ModelAdmin
+
+
+class FiberAdminSite(admin.AdminSite):
+
+    def register(self, model_or_iterable, admin_class=None, **options):
+        if not admin_class:
+            admin_class = ModelAdmin
+        return super(FiberAdminSite, self).register(model_or_iterable, admin_class=admin_class, **options)
+
+
+site = FiberAdminSite(name='fiber_admin')

--- a/fiber/fiber_admin/options.py
+++ b/fiber/fiber_admin/options.py
@@ -1,0 +1,5 @@
+from django.contrib.admin import ModelAdmin as DjangoModelAdmin
+
+
+class ModelAdmin(DjangoModelAdmin):
+    pass


### PR DESCRIPTION
Example usage in admin.py:

```
from fiber import fiber_admin
from models import UserProfile

class UserProfileFiberAdmin(fiber_admin.ModelAdmin):
    pass

fiber_admin.site.register(UserProfile, UserProfileFiberAdmin)
```
