### PR TITLE
Allow valid special characters in URL

### DIFF
--- a/fiber/admin_forms.py
+++ b/fiber/admin_forms.py
@@ -17,7 +17,7 @@ class ContentItemAdminForm(forms.ModelForm):
 class PageForm(forms.ModelForm):
 
     parent = TreeNodeChoiceField(queryset=Page.tree.all(), level_indicator=3*unichr(160), empty_label='---------', required=False)
-    url = forms.RegexField(label=_('URL'), required=False, max_length=100, regex=r'^[-\w/\.\:"]+$',
+    url = forms.RegexField(label=_('URL'), required=False, max_length=100, regex=r'^[-\w/\.\:@#&+\?!="]+$',
         help_text = _("""Example: '/section-1/products' or 'products' or '"some_named_url"'"""),
         error_message = _('This value must contain only letters, numbers, underscores, dashes or slashes.'))
     redirect_page = TreeNodeChoiceField(label=_('Redirect page'), queryset=Page.objects.filter(redirect_page__isnull=True), level_indicator=3*unichr(160), empty_label='---------', required=False)


### PR DESCRIPTION
This allows the following urls to be added:
- Contains get parameters like YouTube (e.g: http://www.youtube.com/watch?v=-d9A2oq1N38&feature=feedrec_grec_index)
- Contains URL fragments like Twitter (e.g: http://twitter.com/#!/cnn)
- Contains an "@" like Flickr (e.g: http://www.flickr.com/photos/40679896@N08)
