### PR TITLE
Bugfix for form submission

### DIFF
--- a/fiber/static/fiber/js/admin.js
+++ b/fiber/static/fiber/js/admin.js
@@ -356,7 +356,9 @@ var ChangeFormDialog = AdminFormDialog.extend({
 			cache: false,
 			context: this,
 			success: function(responseText, statusText, xhr, $form) {
-				var response_change_form = new ChangeForm();
+				var response_change_form = new ChangeForm({
+					url: this.admin_form.options.url
+				});
 
 				response_change_form.get_form_from_HTML(responseText);
 
@@ -368,6 +370,7 @@ var ChangeFormDialog = AdminFormDialog.extend({
 					this.admin_form.set_styling();
 					this.append_form();
 					this.admin_form.set_interaction();
+					busyIndicator.hide();
 				} else {
 					this.after_action_success(responseText, statusText, xhr, $form);
 				}


### PR DESCRIPTION
Hi there,

If ChangeForm doesn't validate properly when adding/editing a new page item via the frontend (such as if the content is left blank), it can't be resubmitted. This patch fixes the issue.

Hope this helps!
