### PR TITLE
Made first step to registering FiberModels

### DIFF
--- a/fiber/admin.py
+++ b/fiber/admin.py
@@ -9,11 +9,7 @@ from app_settings import TEMPLATE_CHOICES
 from models import Page, ContentItem, PageContentItem, Image, File
 import admin_forms as forms
 
-
-class FiberAdminSite(admin.AdminSite):
-    pass
-
-fiber_admin_site = FiberAdminSite(name='fiber_admin')
+import fiber_admin
 
 
 class FileAdmin(admin.ModelAdmin):
@@ -94,7 +90,7 @@ class PageAdmin(MPTTModelAdmin):
     action_links.allow_tags = True
 
 
-class FiberAdminContentItemAdmin(admin.ModelAdmin):
+class FiberAdminContentItemAdmin(fiber_admin.ModelAdmin):
     list_display = ('__unicode__',)
     form = forms.ContentItemAdminForm
     fieldsets = (
@@ -102,7 +98,7 @@ class FiberAdminContentItemAdmin(admin.ModelAdmin):
     )
 
 
-class FiberAdminPageAdmin(MPTTModelAdmin):
+class FiberAdminPageAdmin(fiber_admin.MPTTModelAdmin):
 
     form = forms.FiberAdminPageForm
 
@@ -137,5 +133,5 @@ admin.site.register(Image, ImageAdmin)
 admin.site.register(File, FileAdmin)
 admin.site.register(Page, PageAdmin)
 
-fiber_admin_site.register(ContentItem, FiberAdminContentItemAdmin)
-fiber_admin_site.register(Page, FiberAdminPageAdmin)
+fiber_admin.site.register(ContentItem, FiberAdminContentItemAdmin)
+fiber_admin.site.register(Page, FiberAdminPageAdmin)

--- a/fiber/admin_urls.py
+++ b/fiber/admin_urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls.defaults import *
 
-from admin import fiber_admin_site
+import fiber_admin
 import admin_views
 
 
@@ -8,5 +8,5 @@ urlpatterns = patterns('',
     url(r'^page/(?P<id>\d+)/move_up/$', admin_views.page_move_up, name='fiber_page_move_up'),
     url(r'^page/(?P<id>\d+)/move_down/$', admin_views.page_move_down, name='fiber_page_move_down'),
     url(r'^login/$', admin_views.fiber_login, name='fiber_login'),
-    (r'^fiber_admin/', include(fiber_admin_site.urls)),
+    (r'^fiber_admin/', include(fiber_admin.site.urls)),
 )

--- a/fiber/fiber_admin/__init__.py
+++ b/fiber/fiber_admin/__init__.py
@@ -1,0 +1,13 @@
+from django.contrib import admin
+from options import ModelAdmin, MPTTModelAdmin
+
+
+class FiberAdminSite(admin.AdminSite):
+
+    def register(self, model_or_iterable, admin_class=None, **options):
+        if not admin_class:
+            admin_class = ModelAdmin
+        return super(FiberAdminSite, self).register(model_or_iterable, admin_class=admin_class, **options)
+
+
+site = FiberAdminSite(name='fiber_admin')

--- a/fiber/fiber_admin/options.py
+++ b/fiber/fiber_admin/options.py
@@ -1,0 +1,9 @@
+from django.contrib.admin import ModelAdmin as DjangoModelAdmin
+from mptt.admin import MPTTModelAdmin as DjangoMPTTModelAdmin
+
+
+class ModelAdmin(DjangoModelAdmin):
+    pass
+
+class MPTTModelAdmin(DjangoMPTTModelAdmin):
+    pass


### PR DESCRIPTION
Example usage in admin.py:

from django.contrib import admin

class FileAdmin(admin.ModelAdmin):
    list_display = ('title', '**unicode**')
    date_hierarchy = 'updated'
    search_fields = ('title', )

admin.site.register(File, FileAdmin)
###### 

In fiber it's like this:
###### 

from fiber import fiber_admin

class FileFiberAdmin(fiber_admin.ModelAdmin):
    list_display = ('title', '**unicode**')
    date_hierarchy = 'updated'
    search_fields = ('title', )

fiber_admin.site.register(File, FileFiberAdmin)
###### 

Because we're using a fiber_admin.ModelAdmin, we're able to add more hooks.
Think about: 
- fieldsets that group the frontend editing into "basic" and "advanced"
- loading css, js libraries for frontend
- the sidebar can load all registered models from fiber_admin
