### PR TITLE
Use TEMPLATE_CHOICES to provide drop down on the normal Page admin

### DIFF
--- a/fiber/admin.py
+++ b/fiber/admin.py
@@ -100,7 +100,7 @@ class FiberAdminContentItemAdmin(fiber_admin.ModelAdmin):
 
 class FiberAdminPageAdmin(fiber_admin.MPTTModelAdmin):
 
-    form = forms.FiberAdminPageForm
+    form = forms.PageForm
 
     def __init__(self, *args, **kwargs):
         super(FiberAdminPageAdmin, self).__init__(*args, **kwargs)

--- a/fiber/admin_forms.py
+++ b/fiber/admin_forms.py
@@ -8,6 +8,12 @@ from models import Page, ContentItem
 from utils.urls import is_quoted_url
 
 
+if len(TEMPLATE_CHOICES) == 0:
+    template_choices = [('', _('Default template'))]
+else:
+    template_choices = TEMPLATE_CHOICES
+
+
 class ContentItemAdminForm(forms.ModelForm):
 
     class Meta:
@@ -17,6 +23,7 @@ class ContentItemAdminForm(forms.ModelForm):
 class PageForm(forms.ModelForm):
 
     parent = TreeNodeChoiceField(queryset=Page.tree.all(), level_indicator=3*unichr(160), empty_label='---------', required=False)
+    template_name = forms.ChoiceField(choices=template_choices, required=False, label=_('Template'))
     redirect_page = TreeNodeChoiceField(label=_('Redirect page'), queryset=Page.objects.filter(redirect_page__isnull=True), level_indicator=3*unichr(160), empty_label='---------', required=False)
 
     class Meta:
@@ -36,7 +43,3 @@ class PageForm(forms.ModelForm):
             except KeyError:
                 pass
         return self.cleaned_data['redirect_page']
-
-
-class FiberAdminPageForm(PageForm):
-    template_name = forms.ChoiceField(choices=TEMPLATE_CHOICES, required=False, label=_('Template'))


### PR DESCRIPTION
Fixes issue #48

In the end I avoided the need for the developer to set FIBER_TEMPLATE_CHOICES, so this can remain as an 'advanced' setting for now.
