### PR TITLE
Update django-piston to 0.2.3 (stable)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ These dependencies are automatically installed:
 ::
 
 	PIL>=1.1.7
-	django-piston==0.2.3rc1
+	django-piston==0.2.3
 	django-mptt==0.5.1
 	django-compressor>=0.7.1
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
 
     install_requires=[
         'PIL>=1.1.7',
-        'django-piston==0.2.3rc1',
+        'django-piston==0.2.3',
         'django-mptt==0.5.1',
         'django-compressor>=0.7.1',
     ],


### PR DESCRIPTION
django-fiber setup.py is still requiring piston 0.2.3rc1. I propose to use at least 0.2.3 stable, but i suggest you to change the strict == requirement to a simple >= ... And the same for django-mptt.
