### PR TITLE
Require Pillow instead of Pil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license='Apache License, Version 2.0',
 
     install_requires=[
-        'PIL>=1.1.7',
+        'Pillow==1.7.7',
         'django-piston==0.2.3rc1',
         'django-mptt==0.5.1',
         'django-compressor>=0.7.1',


### PR DESCRIPTION
Let's replace the Python Imaging Library (PIL) with Pillow:
- Pillow is a drop-in replacement of PIL
- Pillow is setuptools compatible (PIL is not)
- Pillow is actively maintained
- It's impossible to install PIL without the PIL website, which is not always available
