### PR TITLE
Using CKEDITOR.editor.destroy() instead of CKEDITOR.remove()

### DIFF
--- a/fiber/static/fiber/js/fiber.ckeditor.js
+++ b/fiber/static/fiber/js/fiber.ckeditor.js
@@ -39,7 +39,7 @@ Fiber.enhance_textarea = function(textarea, auto_height) {
 
 Fiber.remove_textarea = function(textarea) {
 	if (textarea.id in CKEDITOR.instances) {
-		CKEDITOR.remove(CKEDITOR.instances[textarea.id]);
+		CKEDITOR.instances[textarea.id].destroy(false);
 	}
 };
 


### PR DESCRIPTION
The CKEDITOR.remove() function is an internal API, which only removes
the entry in the instances list. It doesn't remove the elements from the
DOM, or write the value back to the <textarea> which destroy() does. See:
- http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.html#.remove
- http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.editor.html#destroy

Fixes: #101
