### PR TITLE
Update fiber/templatetags/fiber_tags.py

### DIFF
--- a/fiber/templatetags/fiber_tags.py
+++ b/fiber/templatetags/fiber_tags.py
@@ -256,6 +256,6 @@ def can_edit(obj, user):
     return PERMISSIONS.can_edit(user, obj)
 
 
-@register.simple_tag(name='fiber_version')
-def show_fiber_version():
+@register.simple_tag()
+def fiber_version():
     return fiber_version


### PR DESCRIPTION
django 1.3.1: 

```
# django.template.base:

...

# line 813
class Library(object):
    
    ...

    #line 866
    def simple_tag(self, func=None, takes_context=None):

        ...

```

doesn't expect a `name` argument.
