### PR TITLE
Added new method to Page model

### DIFF
--- a/fiber/models.py
+++ b/fiber/models.py
@@ -229,6 +229,13 @@ class Page(MPTTModel):
     def is_public_for_user(self, user):
         return user.is_staff or self.is_public
 
+    def has_visible_children(self):
+        visible_children = [page for page in self.get_children() if page.show_in_menu]
+        if visible_children:
+            return True
+        else:
+            return False
+
 
 class PageContentItem(models.Model):
     content_item = models.ForeignKey(ContentItem, related_name='page_content_items', verbose_name=_('content item'))


### PR DESCRIPTION
Check if a Fiber page has visible children (show_in_menu field must be True). Very useful for templating Fiber page menus.

Usage example:

```
{% if fiber_current_pages.0.has_visible_children %}
    <nav class="menu">
        {% show_menu "mainmenu" 2 4 %}
    </nav>
{% endif %}
```
