### PR TITLE
Added decorator to block non-POST requests on login

### DIFF
--- a/fiber/admin_views.py
+++ b/fiber/admin_views.py
@@ -1,4 +1,5 @@
 from django.contrib.admin.views.decorators import staff_member_required
+from django.views.decorators.http import require_POST
 from django.contrib.auth import authenticate, login
 from django.http import HttpResponse, HttpResponseRedirect
 from django.utils import simplejson
@@ -7,6 +8,7 @@ from django.utils.translation import ugettext as _
 from .models import Page
 
 
+@require_POST
 def fiber_login(request):
     username = request.POST['username']
     password = request.POST['password']


### PR DESCRIPTION
Added a decorator to block non-POST request on fiber_login function to make sure IE6 does not trigger a 500 error.  
