### PR TITLE
Use Django 1.5.1 for travis config and test project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 env:
   - DJANGO_VERSION=1.3.7
   - DJANGO_VERSION=1.4.5
-  - DJANGO_VERSION=1.5
+  - DJANGO_VERSION=1.5.1
 install:
   - pip install Django==$DJANGO_VERSION
   - "pip install . --use-mirrors"

--- a/testproject/tox.ini
+++ b/testproject/tox.ini
@@ -35,11 +35,11 @@ deps =
 [testenv:django1.5-py26]
 basepython = python2.6
 deps =
-    Django==1.5
+    Django==1.5.1
     {[testenv]deps}
 
 [testenv:django1.5-py27]
 basepython = python2.7
 deps =
-    Django==1.5
+    Django==1.5.1
     {[testenv]deps}


### PR DESCRIPTION
We still use Django 1.5 for travis and tox. Let's use the newest version: 1.5.1
