### PR TITLE
auto add content items.

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -32,6 +32,8 @@ These settings are optional (default values are shown):
     FIBER_METADATA_PAGE_SCHEMA = {}
     FIBER_METADATA_CONTENT_SCHEMA = {}
 
+    FIBER_AUTO_CREATE_CONTENT_ITEMS = False
+
     COMPRESS = [the opposite of DEBUG]
 
     API_RENDER_HTML = False  # If set to True, you must include 'djangorestframework' in INSTALLED_APPS as well

--- a/fiber/app_settings.py
+++ b/fiber/app_settings.py
@@ -20,6 +20,8 @@ EDITOR = getattr(settings, 'FIBER_EDITOR', 'fiber.editor_definitions.ckeditor.ED
 PAGE_MANAGER = getattr(settings, 'FIBER_PAGE_MANAGER', 'fiber.managers.PageManager')
 CONTENT_ITEM_MANAGER = getattr(settings, 'FIBER_CONTENT_ITEM_MANAGER', 'fiber.managers.ContentItemManager')
 
+AUTO_CREATE_CONTENT_ITEMS = getattr(settings, 'FIBER_AUTO_CREATE_CONTENT_ITEMS', False)
+
 METADATA_PAGE_SCHEMA = getattr(settings, 'FIBER_METADATA_PAGE_SCHEMA', {})
 METADATA_CONTENT_SCHEMA = getattr(settings, 'FIBER_METADATA_CONTENT_SCHEMA', {})
 

--- a/fiber/templatetags/fiber_tags.py
+++ b/fiber/templatetags/fiber_tags.py
@@ -8,7 +8,7 @@ from fiber import __version__ as fiber_version_number
 from fiber.models import Page, ContentItem
 
 from fiber.utils.urls import get_admin_change_url
-from fiber.app_settings import PERMISSION_CLASS
+from fiber.app_settings import PERMISSION_CLASS, AUTO_CREATE_CONTENT_ITEMS
 from fiber.utils import class_loader
 
 PERMISSIONS = class_loader.load_class(PERMISSION_CLASS)
@@ -123,7 +123,9 @@ def show_content(context, content_item_name):
     try:
         content_item = ContentItem.objects.get(name__exact=content_item_name)
     except ContentItem.DoesNotExist:
-        pass
+        if AUTO_CREATE_CONTENT_ITEMS:
+            content_item = ContentItem.objects.create(name=content_item_name)
+            return show_content(context, content_item_name)
 
     context['content_item'] = content_item
 


### PR DESCRIPTION
How to use:

Change the setting:

FIBER_AUTO_CREATE_CONTENT_ITEMS = True

Then for every show_content tag in your template:

 {% show_content "some-slug" %}.

... fiber will auto create a placeholder ContentItem object.
