### PR TITLE
Added a setting for CKEditor that disables the ACF

### DIFF
--- a/fiber/static/fiber/js/fiber.ckeditor.js
+++ b/fiber/static/fiber/js/fiber.ckeditor.js
@@ -23,6 +23,12 @@ Fiber.enhance_textarea = function(textarea, auto_height) {
 	if (auto_height) {
 		CKEDITOR.config.height = window.innerHeight - (($('.ui-dialog').height() - $(textarea).height()) + 140);
 	}
+	
+	if (window.CKEDITOR_DISABLE_ALLOWED_CONTENT_FILTER) {
+		// if CKEDITOR.config.allowedContent is set to true, it disables filtering of HTML elements
+		// see http://docs.ckeditor.com/#!/guide/dev_advanced_content_filter
+		CKEDITOR.config.allowedContent = true;
+	}	
 
 	CKEDITOR.replace(textarea, {
 		skin: 'moono',


### PR DESCRIPTION
Added a setting for CKEditor that disables the Advanced Content Filter.

This is useful for sites that have lots of HTML inside fiber content or older sites that need to be updated to 0.12, for example for browser compatibility reasons.
