### PR TITLE
Use version ranges rather than exact versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ setup(
     license='Apache License, Version 2.0',
 
     install_requires=[
-        'Pillow==2.2.1',
-        'django-mptt==0.6.0',
-        'django_compressor==1.3',
-        'djangorestframework==2.3.8',
-        'easy-thumbnails==1.4',
+        'Pillow>=2.2.1',
+        'django-mptt>=0.6.0',
+        'django_compressor>=1.3',
+        'djangorestframework>=2.3.8',
+        'easy-thumbnails>=1.4',
     ],
 
     description='Django Fiber - a simple, user-friendly CMS for all your Django projects',


### PR DESCRIPTION
Libraries should never specify exact requirements because other versions might be needed by the project or its dependencies.
