### PR TITLE
Replace deprecated _get_val_from_obj

### DIFF
--- a/fiber/utils/json.py
+++ b/fiber/utils/json.py
@@ -87,7 +87,7 @@ class JSONField(models.TextField):
         return self.to_python(value)
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return self._get_json_value(value)
 
 try:


### PR DESCRIPTION
Replaced it with value_from_object

This makes it compatible with Django 2.0+. I'm not sure whether this breaks earlier versions of Django.