### PR TITLE
Made Fiber compatible with Django 2.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ sudo: false
 #    coveralls.
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for Django-Fiber
 1.6 (unreleased)
 ----------------
 
+- Django 2.1 support.
 - Fix for #261: Fiber admin crashes if non-Fiber models use non-integer primary keys.
 - Removed context processor that had been deprecated for several years.
 

--- a/fiber/fiber_admin/options.py
+++ b/fiber/fiber_admin/options.py
@@ -4,7 +4,11 @@ from mptt.admin import MPTTModelAdmin as DjangoMPTTModelAdmin
 
 
 class ModelAdmin(DjangoModelAdmin):
-    pass
+
+    def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
+        # Set is_multipart() to return True to fix fiber_admin requests
+        context['adminform'].form.is_multipart = lambda: True
+        return super(ModelAdmin, self).render_change_form(request, context, add, change, form_url, obj)
 
 
 class MPTTModelAdmin(DjangoMPTTModelAdmin):

--- a/fiber/middleware.py
+++ b/fiber/middleware.py
@@ -50,13 +50,6 @@ class AdminPageMiddleware(MiddlewareMixin):
                 return self.setup_login_session(request)
             if self.show_login(request) or self.show_admin(request, response):
                 return self.modify_response(request, response)
-            # Ugly hack to make Fiber work with Django 2.1 - see PR #266 for more.
-            if not request.POST and '/fiber_admin/fiber/contentitem/' in request.path:
-                content = force_text(response.content)
-                content = content.replace(
-                    '<form action="" method="post" id="contentitem_form" novalidate>',
-                    '<form enctype="multipart/form-data" action="" method="post" id="contentitem_form" novalidate>')
-                response.content = content.encode()
         return response
 
     def should_setup_login_session(self, request):

--- a/fiber/utils/widgets.py
+++ b/fiber/utils/widgets.py
@@ -15,16 +15,16 @@ from fiber.utils.images import get_thumbnail, ThumbnailException
 
 class FiberTextarea(forms.Textarea):
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         attrs['class'] = 'fiber-editor'
-        return super(FiberTextarea, self).render(name, value, attrs)
+        return super(FiberTextarea, self).render(name, value, attrs, renderer)
 
 
 class FiberCombobox(forms.Select):
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         attrs['class'] = 'fiber-combobox'
-        return super(FiberCombobox, self).render(name, value, attrs)
+        return super(FiberCombobox, self).render(name, value, attrs, renderer)
 
 
 class JSONWidget(forms.Textarea):
@@ -42,7 +42,7 @@ class JSONWidget(forms.Textarea):
 
         super(JSONWidget, self).__init__(**kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         attrs['class'] = 'fiber-jsonwidget'
         if isinstance(value, dict):
             value = json.dumps(value)
@@ -81,7 +81,7 @@ class JSONWidget(forms.Textarea):
             'name': name,
             'json': json.dumps(schema),
         }
-        output = super(JSONWidget, self).render(name, value, attrs)
+        output = super(JSONWidget, self).render(name, value, attrs, renderer)
         return output + mark_safe(jquery)
 
 
@@ -89,15 +89,17 @@ class AdminImageWidgetWithPreview(AdminFileWidget):
     """
     A Widget for an ImageField with a preview of the current image.
     """
-    def render(self, name, value, attrs=None):
+
+    def render(self, name, value, attrs=None, renderer=None):
         output = []
         if value and isinstance(value, ImageFieldFile):
             file_name = str(value)
             try:
                 thumbnail = get_thumbnail(file_name, thumbnail_options=DETAIL_THUMBNAIL_OPTIONS)
                 if thumbnail:
-                    output.append('<img src="{0}" width="{1}" height="{2}" />'.format(thumbnail.url, thumbnail.width, thumbnail.height))
+                    output.append('<img src="{0}" width="{1}" height="{2}" />'.format(thumbnail.url, thumbnail.width,
+                                                                                      thumbnail.height))
             except ThumbnailException as e:
                 output.append('<p>{0}</p>'.format(str(e)))
-        output.append(super(AdminImageWidgetWithPreview, self).render(name, value, attrs))
+        output.append(super(AdminImageWidgetWithPreview, self).render(name, value, attrs, renderer))
         return mark_safe(u''.join(output))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Pillow>=2.2.1
-django-mptt>=0.9.0
+Pillow>=6.0.0
+django-mptt>=0.9.1
 django_compressor>=2.2
-djangorestframework>=3.7.7
-easy-thumbnails>=2.5.0
+djangorestframework>=3.9.3
+easy-thumbnails>=2.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,6 @@ deps =
     django111: django>=1.11,<2.0
     django20: django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
 commands =
     python -W module testproject/manage.py test fiber_test
-

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@
 [tox]
 envlist =
     minversion = 3.9.0
-    py{27,34,35,36,37}-django111
-    py{34,35,36,37}-django20
+    py{27,35,36,37}-django111
+    py{35,36,37}-django20
     py{35,36,37}-django21
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,13 @@ envlist =
     minversion = 3.9.0
     py{27,34,35,36,37}-django111
     py{34,35,36,37}-django20
+    py{35,36,37}-django21
 
 [testenv]
 deps =
     django111: django>=1.11,<2.0
     django20: django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
 commands =
     python -W module testproject/manage.py test fiber_test
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py{27,35,36,37}-django111
     py{35,36,37}-django20
     py{35,36,37}-django21
+    py{35,36,37}-django22
 
 [testenv]
 deps =


### PR DESCRIPTION
I have updated django-fiber to be compatible with Django 2.1. Many thanks for Alito for his bug report #264. 
However - editing/creating a ContentItem in the front end is broken in Django 2.1. When you try to save, there's a JS crash. It's happening in the CKEditor Javascript code, and my JS skills are way below what is required to understand that codebase!
As the error only pops up when upgrading Django - it was clear that it was caused in some way by the backend. I tracked it down to the form html generated by the Django admin. In Django 2.0 it was:

    <form enctype="multipart/form-data" action="" method="post" id="contentitem_form" novalidate>

In Django 2.1 it's become:

    <form action="" method="post" id="contentitem_form" novalidate>

So I wrote a very ugly hack: in the middleware I intercept the response, and change the form html to match the old style.
It works. But I'd really appreciate if someone could propose a more elegant solution!