### PR TITLE
Dropped support for Python 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ sudo: false
 # 2. For *one* python version, we add an extra run of the unit tests - with coverage. The results are then fed to
 #    coveralls.
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog for Django-Fiber
 - Reset 'Content-Length' header in AdminPageMiddleware and
   ObfuscateEmailAddressMiddleware to make sure clients read
   the full response.
+- Dropped support for Python 2, cleaned up the code.
 
 
 1.6.1 (2019-10-17)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # django-fiber documentation build configuration file, created by
 # sphinx-quickstart on Fri Mar  2 15:50:27 2012.
@@ -49,8 +48,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'django-fiber'
-copyright = u'%d, Ride The Pony' % datetime.today().year
+project = 'django-fiber'
+copyright = '%d, Ride The Pony' % datetime.today().year
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -193,8 +192,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('index', 'django-fiber.tex', u'django-fiber Documentation',
-     u'Ride The Pony', 'manual'),
+    ('index', 'django-fiber.tex', 'django-fiber Documentation',
+     'Ride The Pony', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -223,8 +222,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'django-fiber', u'django-fiber Documentation',
-     [u'Ride The Pony'], 1)
+    ('index', 'django-fiber', 'django-fiber Documentation',
+     ['Ride The Pony'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -237,8 +236,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ('index', 'django-fiber', u'django-fiber Documentation',
-     u'Ride The Pony', 'django-fiber', 'One line description of project.',
+    ('index', 'django-fiber', 'django-fiber Documentation',
+     'Ride The Pony', 'django-fiber', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/fiber/admin.py
+++ b/fiber/admin.py
@@ -18,7 +18,7 @@ from .utils.widgets import AdminImageWidgetWithPreview
 perms = load_class(PERMISSION_CLASS)
 
 
-class UserPermissionMixin(object):
+class UserPermissionMixin:
 
     def has_change_permission(self, request, obj=None):
         """
@@ -26,7 +26,7 @@ class UserPermissionMixin(object):
         """
         if obj:  # obj can be None for list views
             return perms.can_edit(request.user, obj)
-        return super(UserPermissionMixin, self).has_change_permission(request)
+        return super().has_change_permission(request)
 
     def has_delete_permission(self, request, obj=None):
         """
@@ -50,7 +50,7 @@ class UserPermissionMixin(object):
         """
         Notifies the PERMISSION_CLASS that an `obj` was created by `user`.
         """
-        super(UserPermissionMixin, self).save_model(request, obj, form, change)
+        super().save_model(request, obj, form, change)
         perms.object_created(request.user, obj)
 
 
@@ -61,7 +61,7 @@ class FileAdmin(UserPermissionMixin, admin.ModelAdmin):
     actions = ['really_delete_selected']
 
     def get_actions(self, request):
-        actions = super(FileAdmin, self).get_actions(request)
+        actions = super().get_actions(request)
         if 'delete_selected' in actions:
             del actions[
                 'delete_selected']  # the original delete selected action doesn't remove associated files, because .delete() is never called
@@ -113,7 +113,7 @@ class ImageAdminWithPreview(ImageAdmin):
             request = kwargs.pop("request", None)
             kwargs['widget'] = AdminImageWidgetWithPreview
             return db_field.formfield(**kwargs)
-        return super(ImageAdminWithPreview, self).formfield_for_dbfield(db_field, **kwargs)
+        return super().formfield_for_dbfield(db_field, **kwargs)
 
 
 class ContentItemAdmin(UserPermissionMixin, admin.ModelAdmin):
@@ -159,7 +159,7 @@ class PageAdmin(UserPermissionMixin, MPTTModelAdmin):
 
         absolute_url = page.get_absolute_url()
         if absolute_url:
-            view_on_site += u'<a href="%s" title="%s" target="_blank"><img src="%sfiber/admin/images/world.gif" width="16" height="16" alt="%s" /></a>' % \
+            view_on_site += '<a href="%s" title="%s" target="_blank"><img src="%sfiber/admin/images/world.gif" width="16" height="16" alt="%s" /></a>' % \
                             (absolute_url, _('View on site'), settings.STATIC_URL, _('View on site'))
 
         return view_on_site
@@ -172,25 +172,25 @@ class PageAdmin(UserPermissionMixin, MPTTModelAdmin):
 
         # first child cannot be moved up, last child cannot be moved down
         if not page.is_first_child():
-            actions += u'<a href="%s/move_up" title="%s"><img src="%sfiber/admin/images/arrow_up.gif" width="16" height="16" alt="%s" /></a> ' % (
+            actions += '<a href="{}/move_up" title="{}"><img src="{}fiber/admin/images/arrow_up.gif" width="16" height="16" alt="{}" /></a> '.format(
                 page.pk, _('Move up'), settings.STATIC_URL, _('Move up'))
         else:
-            actions += u'<img src="%sfiber/admin/images/blank.gif" width="16" height="16" alt="" /> ' % (
-                settings.STATIC_URL,)
+            actions += '<img src="{}fiber/admin/images/blank.gif" width="16" height="16" alt="" /> '.format(
+                settings.STATIC_URL)
 
         if not page.is_last_child():
-            actions += u'<a href="%s/move_down" title="%s"><img src="%sfiber/admin/images/arrow_down.gif" width="16" height="16" alt="%s" /></a> ' % (
+            actions += '<a href="{}/move_down" title="{}"><img src="{}fiber/admin/images/arrow_down.gif" width="16" height="16" alt="{}" /></a> '.format(
                 page.pk, _('Move down'), settings.STATIC_URL, _('Move down'))
         else:
-            actions += u'<img src="%sfiber/admin/images/blank.gif" width="16" height="16" alt="" /> ' % (
-                settings.STATIC_URL,)
+            actions += '<img src="{}fiber/admin/images/blank.gif" width="16" height="16" alt="" /> '.format(
+                settings.STATIC_URL)
 
         # add subpage
-        actions += u'<a href="add/?%s=%s" title="%s"><img src="%sfiber/admin/images/page_new.gif" width="16" height="16" alt="%s" /></a> ' % \
+        actions += '<a href="add/?%s=%s" title="%s"><img src="%sfiber/admin/images/page_new.gif" width="16" height="16" alt="%s" /></a> ' % \
                    (self.model._mptt_meta.parent_attr, page.pk, _('Add sub page'), settings.STATIC_URL,
                     _('Add sub page'))
 
-        return u'<span class="nobr">%s</span>' % (actions,)
+        return '<span class="nobr">{}</span>'.format(actions)
 
     action_links.short_description = _('Actions')
     action_links.allow_tags = True
@@ -201,7 +201,7 @@ class FiberAdminContentItemAdmin(UserPermissionMixin, fiber_admin.ModelAdmin):
     form = forms.ContentItemAdminForm
 
     def __init__(self, *args, **kwargs):
-        super(FiberAdminContentItemAdmin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # remove content template choices if there are no choices
         if len(CONTENT_TEMPLATE_CHOICES) == 0:
@@ -219,7 +219,7 @@ class FiberAdminPageAdmin(UserPermissionMixin, fiber_admin.MPTTModelAdmin):
     form = forms.PageForm
 
     def __init__(self, *args, **kwargs):
-        super(FiberAdminPageAdmin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # remove template choices if there are no choices
         if len(TEMPLATE_CHOICES) == 0:
@@ -249,7 +249,7 @@ class FiberAdminPageAdmin(UserPermissionMixin, fiber_admin.MPTTModelAdmin):
             obj.parent = below_page
             obj.insert_at(below_page, position='last-child', save=False)
 
-        super(FiberAdminPageAdmin, self).save_model(request, obj, form, change)
+        super().save_model(request, obj, form, change)
 
 
 admin.site.register(ContentItem, ContentItemAdmin)

--- a/fiber/admin_forms.py
+++ b/fiber/admin_forms.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-from django.utils.six import unichr
 
 from mptt.forms import TreeNodeChoiceField
 
@@ -16,7 +15,7 @@ class ContentItemAdminForm(forms.ModelForm):
         exclude = []
 
     def __init__(self, *args, **kwargs):
-        super(ContentItemAdminForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if len(CONTENT_TEMPLATE_CHOICES) > 0:
             self.fields['template_name'] = forms.ChoiceField(choices=CONTENT_TEMPLATE_CHOICES, required=False, label=_('Content template'))
 
@@ -25,15 +24,15 @@ class PageForm(forms.ModelForm):
 
     meta_description = forms.CharField(widget=forms.Textarea, required=False)
     meta_keywords = forms.CharField(widget=forms.Textarea, required=False)
-    parent = TreeNodeChoiceField(queryset=Page.tree.all(), level_indicator=3 * unichr(160), empty_label='---------', required=False)
-    redirect_page = TreeNodeChoiceField(label=_('Redirect page'), queryset=Page.objects.filter(redirect_page__isnull=True), level_indicator=3 * unichr(160), empty_label='---------', required=False)
+    parent = TreeNodeChoiceField(queryset=Page.tree.all(), level_indicator=3 * chr(160), empty_label='---------', required=False)
+    redirect_page = TreeNodeChoiceField(label=_('Redirect page'), queryset=Page.objects.filter(redirect_page__isnull=True), level_indicator=3 * chr(160), empty_label='---------', required=False)
 
     class Meta:
         model = Page
         exclude = []
 
     def __init__(self, *args, **kwargs):
-        super(PageForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if len(TEMPLATE_CHOICES) > 0:
             self.fields['template_name'] = forms.ChoiceField(choices=TEMPLATE_CHOICES, required=False, label=_('Template'))
 

--- a/fiber/fiber_admin/options.py
+++ b/fiber/fiber_admin/options.py
@@ -8,7 +8,7 @@ class ModelAdmin(DjangoModelAdmin):
     def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
         # Set is_multipart() to return True to fix fiber_admin requests
         context['adminform'].form.is_multipart = lambda: True
-        return super(ModelAdmin, self).render_change_form(request, context, add, change, form_url, obj)
+        return super().render_change_form(request, context, add, change, form_url, obj)
 
 
 class MPTTModelAdmin(DjangoMPTTModelAdmin):

--- a/fiber/middleware.py
+++ b/fiber/middleware.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseRedirect
 from django.template import loader, RequestContext
 from django.utils.encoding import force_text
 from django.utils.html import escape
-from django.utils.six.moves.urllib_parse import unquote
+from urllib.parse import unquote
 
 try:
     from django.urls import reverse
@@ -40,7 +40,7 @@ class AdminPageMiddleware(MiddlewareMixin):
         re.DOTALL)
 
     def __init__(self, *args, **kwargs):
-        super(AdminPageMiddleware, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.editor_settings = import_element(EDITOR)
 
     def process_response(self, request, response):
@@ -157,9 +157,9 @@ class AdminPageMiddleware(MiddlewareMixin):
 
     def get_logout_url(self, request):
         if request.META['QUERY_STRING']:
-            return '%s?next=%s?%s' % (reverse('admin:logout'), request.path_info, request.META['QUERY_STRING'])
+            return '{}?next={}?{}'.format(reverse('admin:logout'), request.path_info, request.META['QUERY_STRING'])
         else:
-            return '%s?next=%s' % (reverse('admin:logout'), request.path_info)
+            return '{}?next={}'.format(reverse('admin:logout'), request.path_info)
 
 
 class ObfuscateEmailAddressMiddleware(MiddlewareMixin):

--- a/fiber/mixins.py
+++ b/fiber/mixins.py
@@ -7,7 +7,7 @@ from django.utils.encoding import force_text
 from .models import Page
 
 
-class FiberPageMixin(object):
+class FiberPageMixin:
     """
     Adds fiber_page and fiber_current_pages to the context
     """
@@ -19,7 +19,7 @@ class FiberPageMixin(object):
     fiber_current_pages = None
 
     def get_context_data(self, **kwargs):
-        super_obj = super(FiberPageMixin, self)
+        super_obj = super()
         if hasattr(super_obj, 'get_context_data'):
             context = super_obj.get_context_data(**kwargs)
         else:

--- a/fiber/models.py
+++ b/fiber/models.py
@@ -8,7 +8,6 @@ except ImportError:
     from django.core.urlresolvers import reverse
 from django.core.files.images import get_image_dimensions
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
@@ -29,7 +28,6 @@ from .utils.json import JSONField
 from .utils.urls import get_named_url_from_quoted_url, is_quoted_url
 
 
-@python_2_unicode_compatible
 class ContentItem(models.Model):
     created = models.DateTimeField(_('created'), auto_now_add=True)
     updated = models.DateTimeField(_('updated'), auto_now=True)
@@ -51,18 +49,18 @@ class ContentItem(models.Model):
         if self.name:
             return self.name
         else:
-            contents = u' '.join(htmlentitydecode(strip_tags(self.content_html)).strip().split())
+            contents = ' '.join(htmlentitydecode(strip_tags(self.content_html)).strip().split())
             if len(contents) > 50:
                 contents = contents[:50] + '...'
             return contents or ugettext('[ EMPTY ]')  # TODO: find out why ugettext_lazy doesn't work here
 
     @classmethod
     def get_add_url(cls):
-        named_url = 'fiber_admin:%s_%s_add' % (cls._meta.app_label, cls._meta.object_name.lower())
+        named_url = 'fiber_admin:{}_{}_add'.format(cls._meta.app_label, cls._meta.object_name.lower())
         return reverse(named_url)
 
     def get_change_url(self):
-        named_url = 'fiber_admin:%s_%s_change' % (self._meta.app_label, self._meta.object_name.lower())
+        named_url = 'fiber_admin:{}_{}_change'.format(self._meta.app_label, self._meta.object_name.lower())
         return reverse(named_url, args=(self.id, ))
 
     def set_used_on_pages_json(self):
@@ -82,7 +80,6 @@ class ContentItem(models.Model):
         return json.dumps(self.used_on_pages_data, sort_keys=True)
 
 
-@python_2_unicode_compatible
 class Page(MPTTModel):
     created = models.DateTimeField(_('created'), auto_now_add=True)
     updated = models.DateTimeField(_('updated'), auto_now=True)
@@ -119,7 +116,7 @@ class Page(MPTTModel):
         else:
             old_url = ''
 
-        super(Page, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
         if old_url:
             new_url = self.get_absolute_url()
@@ -140,17 +137,17 @@ class Page(MPTTModel):
             else:
                 # relative url
                 if self.parent:
-                    return '%s/%s/' % (self.parent.get_absolute_url().rstrip('/'), self.url.strip('/'))
+                    return '{}/{}/'.format(self.parent.get_absolute_url().rstrip('/'), self.url.strip('/'))
                 else:
                     return ''  # TODO: make sure this can never happen (in model.save()?)
 
     @classmethod
     def get_add_url(cls):
-        named_url = 'fiber_admin:%s_%s_add' % (cls._meta.app_label, cls._meta.object_name.lower())
+        named_url = 'fiber_admin:{}_{}_add'.format(cls._meta.app_label, cls._meta.object_name.lower())
         return reverse(named_url)
 
     def get_change_url(self):
-        named_url = 'fiber_admin:%s_%s_change' % (self._meta.app_label, self._meta.object_name.lower())
+        named_url = 'fiber_admin:{}_{}_change'.format(self._meta.app_label, self._meta.object_name.lower())
         return reverse(named_url, args=(self.id, ))
 
     def get_content_for_block(self, block_name):
@@ -188,7 +185,7 @@ class Page(MPTTModel):
                 node = node.parent
             return ancestors
         else:
-            return super(Page, self).get_ancestors(*args, **kwargs)
+            return super().get_ancestors(*args, **kwargs)
 
     def get_ancestors_include_self(self):
         warnings.warn("The `get_ancestors_include_self` method is deprecated,"
@@ -243,11 +240,11 @@ class PageContentItem(models.Model):
     sort = models.IntegerField(_('sort'), blank=True, null=True)
 
     def save(self, *args, **kwargs):
-        super(PageContentItem, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
         self.content_item.set_used_on_pages_json()
 
     def delete(self, *args, **kwargs):
-        super(PageContentItem, self).delete(*args, **kwargs)
+        super().delete(*args, **kwargs)
         self.content_item.set_used_on_pages_json()
 
     def move(self, next_item_id=None, block_name=None):
@@ -287,7 +284,6 @@ def images_directory(instance, filename):
     return os.path.join(IMAGES_DIR, filename)
 
 
-@python_2_unicode_compatible
 class Image(models.Model):
     created = models.DateTimeField(_('created'), auto_now_add=True)
     updated = models.DateTimeField(_('updated'), auto_now=True)
@@ -311,10 +307,10 @@ class Image(models.Model):
             existing_image.delete()
 
         self.get_image_information()
-        super(Image, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
-        super(Image, self).delete(*args, **kwargs)
+        super().delete(*args, **kwargs)
         self.image.storage.delete(self.image.name)
 
     def get_image_information(self):
@@ -337,7 +333,7 @@ class Image(models.Model):
         try:
             thumbnail = get_thumbnail(self.image, thumbnail_options=LIST_THUMBNAIL_OPTIONS)
             if thumbnail:
-                return mark_safe('<img src="{0}" width="{1}" height="{2}" />'.format(thumbnail.url, thumbnail.width, thumbnail.height))
+                return mark_safe('<img src="{}" width="{}" height="{}" />'.format(thumbnail.url, thumbnail.width, thumbnail.height))
         except ThumbnailException as e:
             return str(e)
     preview.short_description = _('Preview')
@@ -347,7 +343,6 @@ def files_directory(instance, filename):
     return os.path.join(FILES_DIR, filename)
 
 
-@python_2_unicode_compatible
 class File(models.Model):
     created = models.DateTimeField(_('created'), auto_now_add=True)
     updated = models.DateTimeField(_('updated'), auto_now=True)
@@ -368,10 +363,10 @@ class File(models.Model):
         for existing_file in existing_files:
             existing_file.delete()
 
-        super(File, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
-        super(File, self).delete(*args, **kwargs)
+        super().delete(*args, **kwargs)
         self.file.storage.delete(self.file.name)
 
     def get_filename(self):

--- a/fiber/permissions.py
+++ b/fiber/permissions.py
@@ -3,7 +3,7 @@ Module that provides a base Permission class. This class may be overridden by ch
 """
 
 
-class Permissions(object):
+class Permissions:
     """
     This class defines the methods that a Permission class should implement.
 

--- a/fiber/rest_api/views.py
+++ b/fiber/rest_api/views.py
@@ -1,6 +1,5 @@
 from django.db.models import Q
 from django.db.models.deletion import ProtectedError
-from django.utils import six
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
 
@@ -38,12 +37,12 @@ class PlainText(renderers.BaseRenderer):
     format = 'txt'
 
     def render(self, data, media_type=None, renderer_context=None):
-        if isinstance(data, six.string_types):
+        if isinstance(data, str):
             return data
         return smart_text(data)
 
 
-class IEUploadFixMixin(object):
+class IEUploadFixMixin:
     """
     A Mixin that fixes issues with IE 8 and IE 9 file uploads.
     Both user agents expect plain text responses when uploading files.
@@ -55,12 +54,12 @@ class IEUploadFixMixin(object):
         user_agent = self.request._request.META['HTTP_USER_AGENT']
         if self.request.method == 'POST' and ('MSIE 8' in user_agent or 'MSIE 9' in user_agent):
             return [PlainText()]
-        return super(IEUploadFixMixin, self).get_renderers()
+        return super().get_renderers()
 
 
 class FiberListCreateAPIView(generics.ListCreateAPIView):
     def create(self, request, *args, **kwargs):
-        response = super(FiberListCreateAPIView, self).create(request, *args, **kwargs)
+        response = super().create(request, *args, **kwargs)
         if hasattr(self, 'object'):
             PERMISSIONS.object_created(request.user, self.object)
         return response
@@ -163,7 +162,7 @@ class FileList(IEUploadFixMixin, FiberListCreateAPIView):
             return Response("Can not order by the passed value.", status=status.HTTP_400_BAD_REQUEST)
 
     def get_queryset(self, *args, **kwargs):
-        qs = super(FileList, self).get_queryset(*args, **kwargs)
+        qs = super().get_queryset(*args, **kwargs)
         qs = PERMISSIONS.filter_files(self.request.user, qs)
         search = self.request.query_params.get('search')
 
@@ -178,7 +177,7 @@ class FileList(IEUploadFixMixin, FiberListCreateAPIView):
 
         sort_order = self.request.query_params.get('sortorder', 'asc')
 
-        qs = qs.order_by('%s%s' % ('-' if sort_order != 'asc' else '', order_by))
+        qs = qs.order_by('{}{}'.format('-' if sort_order != 'asc' else '', order_by))
 
         return qs
 
@@ -226,7 +225,7 @@ class ImageList(IEUploadFixMixin, FiberListCreateAPIView):
             return Response("Can not order by the passed value.", status=status.HTTP_400_BAD_REQUEST)
 
     def get_queryset(self, *args, **kwargs):
-        qs = super(ImageList, self).get_queryset(*args, **kwargs)
+        qs = super().get_queryset(*args, **kwargs)
         qs = PERMISSIONS.filter_images(self.request.user, qs)
         search = self.request.query_params.get('search')
         if search:
@@ -243,7 +242,7 @@ class ImageList(IEUploadFixMixin, FiberListCreateAPIView):
 
         sort_order = self.request.query_params.get('sortorder', 'asc')
 
-        qs = qs.order_by('%s%s' % ('-' if sort_order != 'asc' else '', order_by))
+        qs = qs.order_by('{}{}'.format('-' if sort_order != 'asc' else '', order_by))
 
         return qs
 

--- a/fiber/sitemaps.py
+++ b/fiber/sitemaps.py
@@ -1,4 +1,4 @@
-"""
+r"""
 The `Sitemaps protocol <http://en.wikipedia.org/wiki/Sitemaps>`_ allows a webmaster
 to inform search engines about URLs on a website that are available for crawling.
 Django comes with a high-level framework that makes generating sitemap XML files easy.

--- a/fiber/templatetags/fiber_tags.py
+++ b/fiber/templatetags/fiber_tags.py
@@ -6,7 +6,6 @@ from functools import reduce
 from django import template
 from django.contrib.auth.models import AnonymousUser
 from django.template import TemplateSyntaxError
-from django.utils import six
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
@@ -21,7 +20,7 @@ PERMISSIONS = load_class(PERMISSION_CLASS)
 register = template.Library()
 
 
-class MenuHelper(object):
+class MenuHelper:
     """
     Helper class for show_menu tag, for convenience/clarity
     """
@@ -181,7 +180,7 @@ def show_page_content(context, page_or_block_name, block_name=None):
     {% show_page_content other_page "block_name" %}   use other_page for content items lookup
     """
     page_or_block_name = page_or_block_name or None
-    if isinstance(page_or_block_name, six.string_types) and block_name is None:
+    if isinstance(page_or_block_name, str) and block_name is None:
         # Single argument e.g. {% show_page_content 'main' %}
         block_name = page_or_block_name
         try:

--- a/fiber/utils/fields.py
+++ b/fiber/utils/fields.py
@@ -14,7 +14,7 @@ class FiberURLField(models.CharField):
 
     def __init__(self, verbose_name=None, name=None, **kwargs):
         kwargs['max_length'] = kwargs.get('max_length', 255)
-        super(FiberURLField, self).__init__(verbose_name, name, **kwargs)
+        super().__init__(verbose_name, name, **kwargs)
         self.validators.append(validators.FiberURLValidator())
 
     def formfield(self, **kwargs):
@@ -22,19 +22,19 @@ class FiberURLField(models.CharField):
             'form_class': form_fields.FiberURLField,
         }
         defaults.update(kwargs)
-        return super(FiberURLField, self).formfield(**defaults)
+        return super().formfield(**defaults)
 
 
 class FiberTextField(models.TextField):
     def formfield(self, **kwargs):
         defaults = {'widget': FiberTextarea}
         defaults.update(kwargs)
-        return super(FiberTextField, self).formfield(**defaults)
+        return super().formfield(**defaults)
 
 
 class FiberMarkupField(FiberTextField):
     def pre_save(self, model_instance, add):
-        value = super(FiberMarkupField, self).pre_save(model_instance, add)
+        value = super().pre_save(model_instance, add)
 
         if editor.renderer:
             # also save html
@@ -46,7 +46,7 @@ class FiberMarkupField(FiberTextField):
 class FiberHTMLField(FiberTextField):
     def pre_save(self, model_instance, add):
         if not editor.renderer:
-            return super(FiberHTMLField, self).pre_save(model_instance, add)
+            return super().pre_save(model_instance, add)
         else:
             # render the markup to get the html
             markup_field_name = self.name.replace('_html', '_markup')

--- a/fiber/utils/form_fields.py
+++ b/fiber/utils/form_fields.py
@@ -8,5 +8,5 @@ class FiberURLField(forms.CharField):
     def __init__(self, help_text=None, *args, **kwargs):
         kwargs['help_text'] = kwargs.get('help_text',
                                          _("""Example: 'products' or '/section-1/products/' or '"some_named_url"'"""))
-        super(FiberURLField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.validators.append(validators.FiberURLValidator())

--- a/fiber/utils/html.py
+++ b/fiber/utils/html.py
@@ -1,16 +1,14 @@
 import re
-from django.utils.six import unichr
-from django.utils.six.moves import html_entities
+import html
 
-
-name2codepoint = html_entities.name2codepoint.copy()
+name2codepoint = html.entities.name2codepoint.copy()
 name2codepoint['apos'] = ord("'")
 
 _ENTITY_REF = re.compile(r'&(?:#(\d+)|(?:#x([\da-fA-F]+))|([a-zA-Z]+));')
 _ENTITY_REPLACE = [
-    lambda code: unichr(int(code, 10)) if code else None,
-    lambda code: unichr(int(code, 16)) if code else None,
-    lambda code: unichr(name2codepoint[code]) if code in name2codepoint else None
+    lambda code: chr(int(code, 10)) if code else None,
+    lambda code: chr(int(code, 16)) if code else None,
+    lambda code: chr(name2codepoint[code]) if code in name2codepoint else None
 ]
 
 def htmlentitydecode(s):

--- a/fiber/utils/images.py
+++ b/fiber/utils/images.py
@@ -12,7 +12,7 @@ def get_thumbnail(image, thumbnail_options):
             return thumbnail
         except InvalidImageFormatError as e:
             raise ThumbnailException(str(e))
-        except IOError as e:
+        except OSError as e:
             raise ThumbnailException(str(e))
     except ImportError:
         return

--- a/fiber/utils/import_util.py
+++ b/fiber/utils/import_util.py
@@ -13,7 +13,7 @@ def import_element(path):
     try:
         return import_string(path)
     except ImportError as e:
-        raise ImproperlyConfigured('Error importing %s: %s' % (path, e))
+        raise ImproperlyConfigured('Error importing {}: {}'.format(path, e))
 
 
 def load_class(path, **kwds):

--- a/fiber/utils/json.py
+++ b/fiber/utils/json.py
@@ -1,9 +1,7 @@
-from __future__ import absolute_import
 import json
 
 from django import forms
 from django.db import models
-from django.utils import six
 from django.utils.encoding import force_text
 
 from .widgets import JSONWidget
@@ -24,7 +22,7 @@ class JSONFormField(forms.CharField):
 
         kwargs['widget'] = JSONWidget(schema=self.schema, prefill_from=self.prefill_from)
 
-        super(JSONFormField, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def clean(self, value):
         if not value:
@@ -32,7 +30,7 @@ class JSONFormField(forms.CharField):
         try:
             return json.loads(value)
         except Exception as exception:
-            raise forms.ValidationError(u'JSON decode error: %s' % force_text(exception))
+            raise forms.ValidationError('JSON decode error: %s' % force_text(exception))
 
 
 class JSONField(models.TextField):
@@ -48,18 +46,18 @@ class JSONField(models.TextField):
         else:
             self.prefill_from = None
 
-        super(JSONField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
         kwargs['schema'] = self.schema
         kwargs['prefill_from'] = self.prefill_from
-        return super(JSONField, self).formfield(form_class=JSONFormField, **kwargs)
+        return super().formfield(form_class=JSONFormField, **kwargs)
 
     def to_python(self, value):
         if value is None:
             return None
         try:
-            if isinstance(value, six.string_types):
+            if isinstance(value, str):
                 return json.loads(value)
         except ValueError:
             pass
@@ -68,7 +66,7 @@ class JSONField(models.TextField):
     def _get_json_value(self, value):
         if value is None:
             return ''
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, str):
             return value
         else:
             return json.dumps(value)
@@ -81,7 +79,7 @@ class JSONField(models.TextField):
             return None
         if isinstance(value, dict):
             value = json.dumps(value)
-        return super(JSONField, self).get_db_prep_save(value, *args, **kwargs)
+        return super().get_db_prep_save(value, *args, **kwargs)
 
     def from_db_value(self, value, expression, connection, context):
         return self.to_python(value)

--- a/fiber/utils/urls.py
+++ b/fiber/utils/urls.py
@@ -8,7 +8,7 @@ def get_admin_change_url(instance):
     """
     Return url for editing this instance in the admin.
     """
-    named_url = 'admin:%s_%s_change' % (instance._meta.app_label, instance._meta.object_name.lower())
+    named_url = 'admin:{}_{}_change'.format(instance._meta.app_label, instance._meta.object_name.lower())
     return reverse(named_url, args=(instance.pk,))
 
 

--- a/fiber/utils/widgets.py
+++ b/fiber/utils/widgets.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import json
 
 from warnings import warn
@@ -17,14 +16,14 @@ class FiberTextarea(forms.Textarea):
 
     def render(self, name, value, attrs=None, renderer=None):
         attrs['class'] = 'fiber-editor'
-        return super(FiberTextarea, self).render(name, value, attrs, renderer)
+        return super().render(name, value, attrs, renderer)
 
 
 class FiberCombobox(forms.Select):
 
     def render(self, name, value, attrs=None, renderer=None):
         attrs['class'] = 'fiber-combobox'
-        return super(FiberCombobox, self).render(name, value, attrs, renderer)
+        return super().render(name, value, attrs, renderer)
 
 
 class JSONWidget(forms.Textarea):
@@ -40,7 +39,7 @@ class JSONWidget(forms.Textarea):
         else:
             self.prefill_from = None
 
-        super(JSONWidget, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def render(self, name, value, attrs=None, renderer=None):
         attrs['class'] = 'fiber-jsonwidget'
@@ -81,7 +80,7 @@ class JSONWidget(forms.Textarea):
             'name': name,
             'json': json.dumps(schema),
         }
-        output = super(JSONWidget, self).render(name, value, attrs, renderer)
+        output = super().render(name, value, attrs, renderer)
         return output + mark_safe(jquery)
 
 
@@ -97,9 +96,9 @@ class AdminImageWidgetWithPreview(AdminFileWidget):
             try:
                 thumbnail = get_thumbnail(file_name, thumbnail_options=DETAIL_THUMBNAIL_OPTIONS)
                 if thumbnail:
-                    output.append('<img src="{0}" width="{1}" height="{2}" />'.format(thumbnail.url, thumbnail.width,
+                    output.append('<img src="{}" width="{}" height="{}" />'.format(thumbnail.url, thumbnail.width,
                                                                                       thumbnail.height))
             except ThumbnailException as e:
-                output.append('<p>{0}</p>'.format(str(e)))
-        output.append(super(AdminImageWidgetWithPreview, self).render(name, value, attrs, renderer))
-        return mark_safe(u''.join(output))
+                output.append('<p>{}</p>'.format(str(e)))
+        output.append(super().render(name, value, attrs, renderer))
+        return mark_safe(''.join(output))

--- a/fiber/views.py
+++ b/fiber/views.py
@@ -34,6 +34,6 @@ class FiberTemplateView(FiberPageMixin, TemplateView):
             if fiber_page.redirect_page and fiber_page.redirect_page != fiber_page:  # prevent redirecting to itself
                 return HttpResponsePermanentRedirect(fiber_page.redirect_page.get_absolute_url())
 
-        return super(FiberTemplateView, self).render_to_response(*args, **kwargs)
+        return super().render_to_response(*args, **kwargs)
 
 page = FiberTemplateView.as_view()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version = __import__('fiber').__version__
 if sys.argv[-1] == 'publish':  # upload to pypi
     os.system("python setup.py register sdist bdist_egg bdist_wheel upload")
     print("You probably want to also tag the version now:")
-    print("  git tag -a %s -m 'version %s'" % (version, version))
+    print("  git tag -a {} -m 'version {}'".format(version, version))
     print("  git push --tags")
     sys.exit()
 

--- a/testproject/fiber_test/test_util.py
+++ b/testproject/fiber_test/test_util.py
@@ -24,14 +24,14 @@ def format_list(l, must_sort=True, separator=' '):
 
 
 def condense_html_whitespace(s):
-    s = re.sub("\s\s*", " ", s)
-    s = re.sub(">\s*<", "><", s)
-    s = re.sub(" class=\"\s?(.*?)\s?\"", " class=\"\\1\"", s)
+    s = re.sub(r"\s\s*", " ", s)
+    s = re.sub(r">\s*<", "><", s)
+    s = re.sub(" class=\"\\s?(.*?)\\s?\"", " class=\"\\1\"", s)
     s = s.strip()
     return s
 
 
-class RenderMixin(object):
+class RenderMixin:
     def assertRendered(self, template, expected, context=None):
         t, c = Template(template), Context(context or {})
         self.assertEqual(condense_html_whitespace(t.render(c)), condense_html_whitespace(expected))

--- a/testproject/fiber_test/tests/test_middleware/test_obfuscateemail.py
+++ b/testproject/fiber_test/tests/test_middleware/test_obfuscateemail.py
@@ -1,9 +1,6 @@
 import os
 
-try:
-    import html
-except ImportError:
-    from django.utils.six.moves.html_parser import HTMLParser
+import html
 
 from unittest import skipUnless
 
@@ -31,12 +28,8 @@ class TestEmailAddressObfuscation(SimpleTestCase):
 
     def test_is_html_escaped(self):
         """Unescape the escaped response to see if it's the original content"""
-        try:
-            h = html
-        except:
-            h = HTMLParser()
         content = 'example@example.com'
-        self.assertEqual(h.unescape(
+        self.assertEqual(html.unescape(
             force_text(self.middleware.process_response(None, HttpResponse(content)).content)),
             content)
 

--- a/testproject/fiber_test/tests/test_models.py
+++ b/testproject/fiber_test/tests/test_models.py
@@ -282,33 +282,33 @@ class PageContentItemTest(TestCase):
         item_c = PageContentItem.objects.create(page=page, content_item=content_c, block_name='main', sort=2)
 
         # 1. get content
-        self.assertEqual(u'a b c', get_content(page.id))
+        self.assertEqual('a b c', get_content(page.id))
 
         # 2. move 'a' before 'c'
         item_a.move(item_c.id)
 
-        self.assertEqual(u'b a c', get_content(page.id))
+        self.assertEqual('b a c', get_content(page.id))
 
         # 3. move 'c' before 'a'
         item_c.move(item_a.id)
-        self.assertEqual(u'b c a', get_content(page.id))
+        self.assertEqual('b c a', get_content(page.id))
 
         # 4. move 'b' last
         item_b.move()
-        self.assertEqual(u'c a b', get_content(page.id))
+        self.assertEqual('c a b', get_content(page.id))
 
         # 5. move 'a' to block 'side'
         item_a.move(block_name='side')
-        self.assertEqual(u'c b', get_content(page.id, 'main'))
-        self.assertEqual(u'a', get_content(page.id, 'side'))
+        self.assertEqual('c b', get_content(page.id, 'main'))
+        self.assertEqual('a', get_content(page.id, 'side'))
 
         # 6. move 'c' before 'a' in block 'side'
         item_a = PageContentItem.objects.get(id=item_a.id)
         item_c = PageContentItem.objects.get(id=item_c.id)
 
         item_c.move(item_a.id, block_name='side')
-        self.assertEqual(u'b', get_content(page.id, 'main'))
-        self.assertEqual(u'c a', get_content(page.id, 'side'))
+        self.assertEqual('b', get_content(page.id, 'main'))
+        self.assertEqual('c a', get_content(page.id, 'side'))
 
 
 class TestContentItem(TestCase):

--- a/testproject/fiber_test/tests/test_templatetags/test_show_menu.py
+++ b/testproject/fiber_test/tests/test_templatetags/test_show_menu.py
@@ -520,7 +520,7 @@ class TestEdgeCases(TestCase):
 
 class TestStaffMenu(BaseTestShowMenu):
     def setUp(self):
-        super(TestStaffMenu, self).setUp()
+        super().setUp()
         self.staff = User.objects.create_user('staff', 'staff@example.com', password='staff')
         self.staff.is_staff = True
         self.staff.save()

--- a/testproject/fiber_test/tests/test_utils/test_import_util.py
+++ b/testproject/fiber_test/tests/test_utils/test_import_util.py
@@ -4,7 +4,7 @@ from django.test import SimpleTestCase
 from fiber.utils.import_util import import_element, load_class
 
 
-class TestClass(object):
+class TestClass:
     def __init__(self, foo=None):
         self.foo = foo
 

--- a/testproject/fiber_test/tests/test_utils/test_middleware.py
+++ b/testproject/fiber_test/tests/test_utils/test_middleware.py
@@ -1,11 +1,9 @@
-from __future__ import unicode_literals
-
 import django
 from django.test import RequestFactory
 from django.http import HttpResponse
 
 
-class TestNewStyleMiddlewareMixin(object):
+class TestNewStyleMiddlewareMixin:
     middleware_factory = NotImplemented
 
     if django.VERSION >= (1, 10):

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
     minversion = 3.9.0
-    py{27,35,36,37}-django111
+    py{35,36,37}-django111
     py{35,36,37}-django20
     py{35,36,37}-django21
     py{35,36,37}-django22


### PR DESCRIPTION
I've dropped Python 2 from the test matrix. 
I also took the opportunity to clean up the codebase:

1. Removing code that was only needed because of python 2.7 (e.g. super(Foo, self)) using the `pyupgrade` script.
2. Removing the `six` library.
3. Removing the `python2_unicode_compatible` decorator.

CI crashes at present - but the tests pass, it's only the coverage part that crashes. I think it's trying and failing to use Django 3.0. I will take a closer look when I have some time.