### PR TITLE
Temporary fix for broken CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ python:
   - "3.7"
 install:
   - pip install tox-travis
-  - if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ]; then pip install coveralls -r requirements.txt; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ]; then pip install django==2.2.8 coveralls -r requirements.txt; fi
 
 script:
   # Run against all the Python interpreter and Django versions specified in the tox.ini file.


### PR DESCRIPTION
CI is currently broken because the coverage report installs the latest version of Django - i.e. 3.0 - and Fiber is not yet compatible with it.
As a temporary fix this PR hard-codes the use of Django 2.2 - we can reverse it once we've upgraded Fiber.