### PR TITLE
Upgrade Django version for making docs.

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,1 +1,1 @@
-Django==1.8
+Django==2.2


### PR DESCRIPTION
Github is warning to upgrade the Django version specified for making the docs.