### PR TITLE
Check support for Django 3.2.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for Django-Fiber
 1.9 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Django 3.2 support.
 
 
 1.8.1 (2020-09-15)

--- a/fiber/apps.py
+++ b/fiber/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class FiberConfig(AppConfig):
+    name = 'fiber'
+    default_auto_field = 'django.db.models.AutoField'

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -4,12 +4,13 @@ DEBUG = True
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'testproject_db',                # Or path to database file if using sqlite3.
-        'USER': '',                              # Not used with sqlite3.
-        'PASSWORD': '',                          # Not used with sqlite3.
-        'HOST': '',                              # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                              # Set to empty string for default. Not used with sqlite3.
+        'ENGINE': 'django.db.backends.sqlite3',
+        # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'NAME': 'testproject_db',  # Or path to database file if using sqlite3.
+        'USER': '',  # Not used with sqlite3.
+        'PASSWORD': '',  # Not used with sqlite3.
+        'HOST': '',  # Set to empty string for localhost. Not used with sqlite3.
+        'PORT': '',  # Set to empty string for default. Not used with sqlite3.
     }
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,15 +7,15 @@
 
 [tox]
 envlist =
-    py{35,36,37,38}-django22
-    py{36,37,38}-django30
-    py{36,37,38}-django31
+    py{35,36,37}-django22
+    py{36,37,38,39}-django31
+    py{36,37,38,39}-django32
 
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<4.0
     -r{toxinidir}/requirements.txt
 setenv =
     PYTHONWARNINGS=module


### PR DESCRIPTION
An early check as to whether this project works with Django 3.2.

- The test suite passes with Tox.
- I haven't tested the app in a browser.

Dependencies e.g. django-compressor have not been certified "3.2 compatible" yet so it's probably premature to merge this PR and release - I'm just uploading this code to say that it will be (hopefully) a straightforward task. 

When the projects that Fiber depends on are upgraded, either I can take another look at this PR - or if I'm elsewhere someone else can pick it up :-)