### PR TITLE
Simplify docs requirements.

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,1 +1,1 @@
-Django==2.2.21
+Django


### PR DESCRIPTION
We're getting automated pull requests from dependabot because the docs-requirements.txt file specifies a precise version of Django - so we get an alert for each security update.

Security updates are not that important for building docs locally. So I've changed the requirements file to just install Django (latest version) so hopefully we will not get these alerts anymore.