### PR TITLE
docs: Fix a few typos

### DIFF
--- a/fiber/static/fiber/js/jquery-1.5.2.js
+++ b/fiber/static/fiber/js/jquery-1.5.2.js
@@ -1163,7 +1163,7 @@ jQuery.extend({
 	jQuery.support.noCloneChecked = input.cloneNode( true ).checked;
 
 	// Make sure that the options inside disabled selects aren't marked as disabled
-	// (WebKit marks them as diabled)
+	// (WebKit marks them as disabled)
 	select.disabled = true;
 	jQuery.support.optDisabled = !opt.disabled;
 
@@ -1866,7 +1866,7 @@ jQuery.fn.extend({
 					classNames = value.split( rspaces );
 
 				while ( (className = classNames[ i++ ]) ) {
-					// check each className given, space seperated list
+					// check each className given, space separated list
 					state = isBool ? state : !self.hasClass( className );
 					self[ state ? "addClass" : "removeClass" ]( className );
 				}

--- a/fiber/static/fiber/js/jquery-ui-1.9m4/external/jquery.global.js
+++ b/fiber/static/fiber/js/jquery-ui-1.9m4/external/jquery.global.js
@@ -311,8 +311,8 @@ var en = cultures["default"] = cultures.en = Globalization.extend(true, {
     // For a specific culture like "es-CL", the 'language' field refers to the
     // neutral, generic culture information for the language it is using.
     // This is not always a simple matter of the string before the dash.
-    // For example, the "zh-Hans" culture is netural (Simplified Chinese).
-    // And the 'zh-SG' culture is Simplified Chinese in Singapore, whose lanugage
+    // For example, the "zh-Hans" culture is neutral (Simplified Chinese).
+    // And the 'zh-SG' culture is Simplified Chinese in Singapore, whose language
     // field is "zh-CHS", not "zh".
     // This field should be used to navigate from a specific culture to it's
     // more general, neutral culture. If a culture is already as general as it

--- a/fiber/static/fiber/js/jquery-ui-1.9m4/external/qunit.js
+++ b/fiber/static/fiber/js/jquery-ui-1.9m4/external/qunit.js
@@ -945,7 +945,7 @@ QUnit.equiv = function () {
         // for string, boolean, number and null
         function useStrictEquality(b, a) {
             if (b instanceof a.constructor || a instanceof b.constructor) {
-                // to catch short annotaion VS 'new' annotation of a declaration
+                // to catch short annotation VS 'new' annotation of a declaration
                 // e.g. var i = 1;
                 //      var j = new Number(1);
                 return a == b;
@@ -972,7 +972,7 @@ QUnit.equiv = function () {
             "regexp": function (b, a) {
                 return QUnit.objectType(b) === "regexp" &&
                     a.source === b.source && // the regex itself
-                    a.global === b.global && // and its modifers (gmi) ...
+                    a.global === b.global && // and its modifiers (gmi) ...
                     a.ignoreCase === b.ignoreCase &&
                     a.multiline === b.multiline;
             },

--- a/fiber/static/fiber/js/jquery-ui-1.9m4/jquery-1.4.4.js
+++ b/fiber/static/fiber/js/jquery-ui-1.9m4/jquery-1.4.4.js
@@ -983,7 +983,7 @@ return (window.jQuery = window.$ = jQuery);
 	};
 
 	// Make sure that the options inside disabled selects aren't marked as disabled
-	// (WebKit marks them as diabled)
+	// (WebKit marks them as disabled)
 	select.disabled = true;
 	jQuery.support.optDisabled = !opt.disabled;
 
@@ -1550,7 +1550,7 @@ jQuery.fn.extend({
 					classNames = value.split( rspaces );
 
 				while ( (className = classNames[ i++ ]) ) {
-					// check each className given, space seperated list
+					// check each className given, space separated list
 					state = isBool ? state : !self.hasClass( className );
 					self[ state ? "addClass" : "removeClass" ]( className );
 				}

--- a/fiber/static/fiber/js/jquery-ui-1.9m4/ui/jquery-ui.js
+++ b/fiber/static/fiber/js/jquery-ui-1.9m4/ui/jquery-ui.js
@@ -7773,7 +7773,7 @@ $.extend(Datepicker.prototype, {
 				// this breaks the change event in IE
 				inst.input.is(':visible') && !inst.input.is(':disabled') && inst.input[0] != document.activeElement)
 			inst.input.focus();
-		// deffered render of the years select (to avoid flashes on Firefox) 
+		// deferred render of the years select (to avoid flashes on Firefox) 
 		if( inst.yearshtml ){
 			var origyearshtml = inst.yearshtml;
 			setTimeout(function(){
@@ -9963,7 +9963,7 @@ $.fn.position = function( options ) {
 		basePosition = target.offset();
 	}
 
-	// force my and at to have valid horizontal and veritcal positions
+	// force my and at to have valid horizontal and vertical positions
 	// if a value is missing or invalid, it will be converted to center 
 	$.each( [ "my", "at" ], function() {
 		var pos = ( options[this] || "" ).split( " " );

--- a/fiber/static/fiber/js/jquery-ui-1.9m4/ui/jquery.ui.datepicker.js
+++ b/fiber/static/fiber/js/jquery-ui-1.9m4/ui/jquery.ui.datepicker.js
@@ -704,7 +704,7 @@ $.extend(Datepicker.prototype, {
 				// this breaks the change event in IE
 				inst.input.is(':visible') && !inst.input.is(':disabled') && inst.input[0] != document.activeElement)
 			inst.input.focus();
-		// deffered render of the years select (to avoid flashes on Firefox) 
+		// deferred render of the years select (to avoid flashes on Firefox) 
 		if( inst.yearshtml ){
 			var origyearshtml = inst.yearshtml;
 			setTimeout(function(){

--- a/fiber/static/fiber/js/jquery-ui-1.9m4/ui/jquery.ui.position.js
+++ b/fiber/static/fiber/js/jquery-ui-1.9m4/ui/jquery.ui.position.js
@@ -52,7 +52,7 @@ $.fn.position = function( options ) {
 		basePosition = target.offset();
 	}
 
-	// force my and at to have valid horizontal and veritcal positions
+	// force my and at to have valid horizontal and vertical positions
 	// if a value is missing or invalid, it will be converted to center 
 	$.each( [ "my", "at" ], function() {
 		var pos = ( options[this] || "" ).split( " " );

--- a/fiber/static/fiber/js/jquery.json-2.2.js
+++ b/fiber/static/fiber/js/jquery.json-2.2.js
@@ -15,13 +15,13 @@
  */
  
 (function($) {
-    /** jQuery.toJSON( json-serializble )
+    /** jQuery.toJSON( json-serializable )
         Converts the given argument into a JSON respresentation.
 
         If an object has a "toJSON" function, that will be used to get the representation.
         Non-integer/string keys are skipped in the object, as are keys that point to a function.
 
-        json-serializble:
+        json-serializable:
             The *thing* to be converted.
      **/
     $.toJSON = function(o)


### PR DESCRIPTION
There are small typos in:
- fiber/static/fiber/js/jquery-1.5.2.js
- fiber/static/fiber/js/jquery-ui-1.9m4/external/jquery.global.js
- fiber/static/fiber/js/jquery-ui-1.9m4/external/qunit.js
- fiber/static/fiber/js/jquery-ui-1.9m4/jquery-1.4.4.js
- fiber/static/fiber/js/jquery-ui-1.9m4/ui/jquery-ui.js
- fiber/static/fiber/js/jquery-ui-1.9m4/ui/jquery.ui.datepicker.js
- fiber/static/fiber/js/jquery-ui-1.9m4/ui/jquery.ui.position.js
- fiber/static/fiber/js/jquery.json-2.2.js

Fixes:
- Should read `vertical` rather than `veritcal`.
- Should read `separated` rather than `seperated`.
- Should read `disabled` rather than `diabled`.
- Should read `deferred` rather than `deffered`.
- Should read `serializable` rather than `serializble`.
- Should read `neutral` rather than `netural`.
- Should read `modifiers` rather than `modifers`.
- Should read `language` rather than `lanugage`.
- Should read `annotation` rather than `annotaion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md