### PR TITLE
Checking it works with Django 4.1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /dist/
 /testproject/reports/
 /testproject/static/
+/testproject/media/
 django_fiber.egg-info
 .tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for Django-Fiber
 1.10 (unreleased)
 -----------------
 
-- Checked compatibility with Django 4.0.
+- Checked compatibility with Django 4.0, 4.1.
 
 
 1.9.1 (2021-11-02)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django-mptt>=0.13
-django_compressor>=2.4
-djangorestframework>=3.12.4
+django_compressor>=4.1
+djangorestframework>=3.14
 easy-thumbnails>=2.7.2

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,9 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.1',
     ],
     keywords=['cms', 'django']
 )

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@
 
 [tox]
 envlist =
-    py{36,37}-django22
     py{36,37,38,39}-django32
+    py{38,39,310}-django40
     py{38,39,310}-django40
 
 [testenv]
@@ -16,6 +16,7 @@ deps =
     django22: Django>=2.2,<2.3
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     -r{toxinidir}/requirements.txt
 setenv =
     PYTHONWARNINGS=module

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@
 envlist =
     py{36,37,38,39}-django32
     py{38,39,310}-django40
-    py{38,39,310}-django40
+    py{38,39,310}-django41
 
 [testenv]
 deps =


### PR DESCRIPTION
As per subject line - the packages that django-fiber depends on have released versions compatible with Django 4.1 - except for django-mptt. That project has been abandoned.

Nevertheless - django-fiber seems to work. As usual I would welcome a second set of eyeballs to test this.