### PR TITLE
WIP: check compatibility with Django 4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false # If one test fails, complete the other jobs.
       matrix:
-        python: [ 3.8, 3.9, '3.10', '3.11' ]
+        python: [ 3.9, '3.10', '3.11' ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -26,12 +26,12 @@ jobs:
       - name: Run tests
         run: tox
       - name: Coverage
-        if: ${{ matrix.python == 3.8 }}
+        if: ${{ matrix.python == 3.9 }}
         run: |
           pip install coverage[toml]
           coverage run testproject/manage.py test fiber_test
       - name: Upload coverage
-        if: ${{ matrix.python == 3.8 }}
+        if: ${{ matrix.python == 3.9 }}
         uses: codecov/codecov-action@v1
         with:
           name: Python ${{ matrix.python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # If one test fails, complete the other jobs.
       matrix:
-        python: [ 3.6, 3.7, 3.8, 3.9, '3.10' ]
+        python: [ 3.8, 3.9, '3.10' ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false # If one test fails, complete the other jobs.
       matrix:
-        python: [ 3.8, 3.9, '3.10' ]
+        python: [ 3.8, 3.9, '3.10', '3.11' ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for Django-Fiber
 1.11 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Dropped support for Django 2.2, 4.0 and Python 3.6, 3.7.
 
 
 1.10 (2022-10-08)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django-mptt>=0.13
-django_compressor>=4.1
+django_compressor>=4.4
 djangorestframework>=3.14
 easy-thumbnails>=2.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django-mptt>=0.13
+django-mptt>=0.15
 django_compressor>=4.4
-djangorestframework>=3.14
-easy-thumbnails>=2.7.2
+djangorestframework>=3.15.0
+easy-thumbnails>=2.8.5

--- a/tox.ini
+++ b/tox.ini
@@ -7,15 +7,13 @@
 
 [tox]
 envlist =
-    py{36,37,38,39}-django32
+    py{38,39}-django32
     py{38,39,310}-django40
     py{38,39,310}-django41
 
 [testenv]
 deps =
-    django22: Django>=2.2,<2.3
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     -r{toxinidir}/requirements.txt
 setenv =
@@ -25,8 +23,6 @@ commands =
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,13 @@ envlist =
     py{38,39}-django32
     py{38,39,310}-django40
     py{38,39,310}-django41
+    py{38,39,310,311}-django42
 
 [testenv]
 deps =
     django32: Django>=3.2,<4.0
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0
     -r{toxinidir}/requirements.txt
 setenv =
     PYTHONWARNINGS=module
@@ -26,3 +28,4 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,10 @@
 
 [tox]
 envlist =
-    py{38,39}-django32
-    py{38,39,310}-django40
-    py{38,39,310}-django41
-    py{38,39,310,311}-django42
+    py{39}-django32
+    py{39,310}-django40
+    py{39,310}-django41
+    py{39,310,311}-django42
 
 [testenv]
 deps =
@@ -25,7 +25,6 @@ commands =
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311


### PR DESCRIPTION
I am opening this PR to track work on making django-fiber work with Django 4.2.

At present several of the packages that django-fiber depends on are **not** 4.2-ready:

- django-mptt: "This project is currently unmaintained". We can either switch to an alternative package (which sounds like a lot of work, and it might be as easy for me to just stop using django-fiber and switch to an alternative) or else YOLO and hope that it still works for Django 4.2.
- django_compressor: v4.4 is compatible.
- djangorestframework: tested against 4.2 in the main branch, but not released yet.
- easy-thumbnails: not tested against 4.2 yet.

So we only have 1 out of 4 packages that are ready. _Personally_ I really want to wait for at least djangorestframework to be 4.2 compatible, as it's a complex beast of a package.

Anyone who wants to contribute to this MR: please feel welcome to help out :-)